### PR TITLE
Add multi-column footer with contact and policy links

### DIFF
--- a/index.html
+++ b/index.html
@@ -345,14 +345,47 @@
       margin: 0 auto;
       display: flex;
       flex-wrap: wrap;
-      align-items: center;
+      align-items: flex-start;
       justify-content: space-between;
-      gap: 10px;
+      gap: clamp(16px, 3vw, 32px);
+    }
+
+    .site-footer__brand {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      max-width: 240px;
     }
 
     .site-footer__version {
       font-weight: 700;
       color: var(--accent);
+    }
+
+    .site-footer__column {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      min-width: 160px;
+    }
+
+    .site-footer__column-title {
+      margin: 0;
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: 0.4px;
+      color: var(--text);
+      text-transform: uppercase;
+    }
+
+    .site-footer__link {
+      color: inherit;
+      transition: color 0.2s ease;
+    }
+
+    .site-footer__link:hover,
+    .site-footer__link:focus-visible {
+      color: var(--text);
     }
 
     @keyframes heroCarousel {
@@ -418,6 +451,11 @@
 
       .landing-main {
         padding-inline: clamp(var(--space), 8vw, var(--space-lg));
+      }
+
+      .site-footer__inner {
+        flex-direction: column;
+        align-items: flex-start;
       }
     }
   </style>
@@ -515,8 +553,26 @@
   </main>
   <footer class="site-footer">
     <div class="site-footer__inner">
-      <span class="site-footer__version">ReLead EDU</span>
-      <span>ReLead<sup>©</sup> Todos los Derechos Reservados</span>
+      <div class="site-footer__brand">
+        <span class="site-footer__version">ReLead EDU</span>
+        <span>ReLead<sup>©</sup> Todos los Derechos Reservados</span>
+      </div>
+      <div class="site-footer__column" aria-label="Contacto">
+        <p class="site-footer__column-title">Contacto</p>
+        <a class="site-footer__link" href="mailto:comercial@relead.edu">comercial@relead.edu</a>
+        <a class="site-footer__link" href="tel:+526622000000">+52 662 200 0000</a>
+      </div>
+      <nav class="site-footer__column" aria-label="Políticas">
+        <p class="site-footer__column-title">Políticas</p>
+        <a class="site-footer__link" href="#privacidad">Aviso de privacidad</a>
+        <a class="site-footer__link" href="#terminos">Términos de uso</a>
+      </nav>
+      <div class="site-footer__column" aria-label="Canales sociales">
+        <p class="site-footer__column-title">Síguenos</p>
+        <a class="site-footer__link" href="https://www.linkedin.com/company/relead" target="_blank" rel="noreferrer">LinkedIn</a>
+        <a class="site-footer__link" href="https://www.facebook.com/relead" target="_blank" rel="noreferrer">Facebook</a>
+        <a class="site-footer__link" href="https://www.youtube.com/@relead" target="_blank" rel="noreferrer">YouTube</a>
+      </div>
     </div>
   </footer>
 </body>


### PR DESCRIPTION
## Summary
- expand the landing footer with dedicated columns for brand, contact, policies, and social channels
- add footer typography and link styles to support the new layout while keeping contrast in light and dark modes
- ensure the footer stacks vertically on small screens for better readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d182268b0c832caf1b7122238decdc